### PR TITLE
add fullVersionList property to UADataValues

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -23,7 +23,8 @@ interface UADataValues {
     readonly bitness?: string;
     readonly model?: string;
     readonly platformVersion?: string;
-    readonly uaFullVersion?: string;
+    readonly uaFullVersion?: string; // Deprecated in favor of fullVersionList
+    readonly fullVersionList?: NavigatorUABrandVersion[];
 }
 
 // https://wicg.github.io/ua-client-hints/#dictdef-ualowentropyjson


### PR DESCRIPTION
The spec was updated to deprecate `uaFullVersion` in favor of `fullVersionList`

I didn't check to see if there was anything else new, since it wasn't being used in my code, but if it's helpful I can take a look.

https://wicg.github.io/ua-client-hints/#interface