### PR TITLE
rename formFactor to formFactors

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -21,7 +21,7 @@ interface UADataValues {
     readonly platform?: string;
     readonly architecture?: string;
     readonly bitness?: string;
-    readonly formFactor?: string[];
+    readonly formFactors?: string[];
     readonly model?: string;
     readonly platformVersion?: string;
     /** @deprecated in favour of fullVersionList */


### PR DESCRIPTION
Hi! 
The property in `UADataValues` is `formFactor`. but the name actually used in browsers is `formFactors`, and [the W3C documentation](https://wicg.github.io/ua-client-hints/#dictdef-uadatavalues) also uses `formFactors`, so I renamed it accordingly.